### PR TITLE
Fix uninitialized constant X::ActiveRecord::VERSION

### DIFF
--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -23,7 +23,7 @@ module MultiTenant
           # Avoid primary_key errors when using composite primary keys (e.g. id, tenant_id)
           def primary_key
             return @primary_key if @primary_key
-            return @primary_key = super || DEFAULT_ID_FIELD if ActiveRecord::VERSION::MAJOR < 5
+            return @primary_key = super || DEFAULT_ID_FIELD if ::ActiveRecord::VERSION::MAJOR < 5
 
             primary_object_keys = Array.wrap(connection.schema_cache.primary_keys(table_name)) - [partition_key]
             if primary_object_keys.size == 1


### PR DESCRIPTION
When the class that calls `multi_tenant` has another ActiveRecord class included, then this reference may resolve to the wrong ActiveRecord class. Make sure that does not happen by using ::ActiveRecord.

This happened for example if activerecord-multi-tenant and mobility gem were used in the same project.

```
NameError (uninitialized constant Mobility::ActiveRecord::VERSION)
```

```
class Model < ApplicationRecord
  extend Mobility

  multi_tenant :tenant
end
```

The mobility gem defines a class named `Mobility::ActiveRecord` and includes that into the class above.